### PR TITLE
[PR] Add scripts for a build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 /css
 /js
+/build
+dashboard.tar.gz

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,6 +74,16 @@ module.exports = function( grunt ) {
 			}
 		},
 
+		copy: {
+			main: {
+				files: [
+					{ expand: true, src: [ "css/*" ], dest: "build/" },
+					{ expand: true, src: [ "js/*" ], dest: "build/" },
+					{ expand: true, src: [ "index.html" ], dest: "build/" }
+				]
+			}
+		},
+
 		watch: {
 			styles: {
 				files: [ "*.html", "src/css/*.css", "src/js/*.js" ],
@@ -98,6 +108,7 @@ module.exports = function( grunt ) {
 
 	grunt.loadNpmTasks( "grunt-postcss" );
 	grunt.loadNpmTasks( "grunt-contrib-concat" );
+	grunt.loadNpmTasks( "grunt-contrib-copy" );
 	grunt.loadNpmTasks( "grunt-contrib-clean" );
 	grunt.loadNpmTasks( "grunt-contrib-watch" );
 	grunt.loadNpmTasks( "grunt-contrib-connect" );
@@ -108,5 +119,6 @@ module.exports = function( grunt ) {
 
 	// Default task(s).
 	grunt.registerTask( "default", [ "jscs", "jshint", "stylelint", "concat", "postcss", "uglify", "clean" ] );
+	grunt.registerTask( "build", [ "default", "copy" ] );
 	grunt.registerTask( "serve", [ "connect", "watch" ] );
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wsu-a11y-dashboard",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/washingtonstateuniversity/wsu-a11y-dashboard"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-concat": "~1.0.1",
     "grunt-contrib-connect": "^1.0.2",
+    "grunt-contrib-copy": "~1.0.0",
     "grunt-contrib-cssmin": "~2.1.0",
     "grunt-contrib-jshint": "^1.1.0",
     "grunt-contrib-uglify": "^2.2.0",
@@ -26,5 +27,9 @@
     "grunt-stylelint": "^0.7.0",
     "react": "^15.5.4",
     "react-dom": "^15.5.4"
+  },
+  "scripts": {
+    "build": "webpack && rm -f build && grunt build",
+    "distro": "rm -f dashboard.tar* && webpack && rm -rf build && grunt build && tar --create --file=dashboard.tar build && gzip dashboard.tar"
   }
 }


### PR DESCRIPTION
Rather than run `npm install` and `webpack` and others on the server, we can just ship the built files.